### PR TITLE
[Propuesta] Dándole sentido al SRDF

### DIFF
--- a/proceso-entrenador.md
+++ b/proceso-entrenador.md
@@ -10,13 +10,15 @@ El proceso Entrenador obtendrá de la línea de comandos su nombre y la ruta del
 
 En el Pokédex existirá un subdirectorio con el nombre de cada Entrenador, por lo que el proceso deberá leer su archivo de metadata del Pokédex y así conocer su Hoja de Viaje.
 
-La Hoja de Viaje especificará la lista de Mapas que el Entrenador deberá recorrer. Para comenzar su aventura Pokémon, el Entrenador obtendrá la dirección IP y puerto del primer Mapa leyendo el correspondiente _archivo de metadata_. Una vez establecida la conexión, el Entrenador quedará esperando a cada aviso del Mapa de que es su turno de realizar una acción. En este momento, el Entrenador, según el estado en que se encuentre:
+La Hoja de Viaje especificará la lista de Mapas que el Entrenador deberá recorrer. Para comenzar su aventura Pokémon, el Entrenador obtendrá la dirección IP y puerto del primer Mapa leyendo el correspondiente _archivo de metadata_. Una vez establecida la conexión, el Entrenador enviará al Mapa la primera de sus solicitudes de operación. Cada vez que obtenga una respuesta del Mapa, el Entrenador realizará la siguiente solicitud que tenga, hasta cumplir los objetivos del Mapa.
 
-1. **Solicitará** al mapa **la ubicación** de la PokeNest del próximo Pokémon que desea obtener, en caso de aún no conocerla.
+Dependiendo del estado en que se encuentre, el Entrenador enviará alguno de estos pedidos al Mapa:
+
+1. **Solicitará la ubicación** de la PokeNest del próximo Pokémon que desea obtener, en caso de aún no conocerla.
 1. **Avanzará una posición** hacia la siguiente PokeNest[^1], informando el movimiento al Mapa, en caso de aún no haber llegado a ella.
-1. Al llegar a las coordenadas de una PokeNest, **solicitará** al mapa **atrapar un Pokémon**. El Entrenador quedará bloqueado hasta que el Mapa le confirme la captura del Pokémon. En ese momento, el Entrenador evaluará (e informará al Mapa) si debe continuar atrapando Pokémons en este Mapa, o si ya cumplió sus objetivos en el mismo.
+1. Al llegar a las coordenadas de una PokeNest, **solicitará atrapar un Pokémon**.
 
-Tras informarle al Mapa que cumplió sus objetivos, el Entrenador **copiará la medalla del Mapa a su directorio**, se desconectará del mismo, y procederá a repetir toda la operatoria con el siguiente Mapa de su Hoja de Viaje.
+Cuando reciba la confirmación de captura del último Pokemon del Mapa, el Entrenador **copiará la medalla del Mapa a su directorio**, se desconectará del mismo, y procederá a repetir toda la operatoria con el siguiente Mapa de su Hoja de Viaje.
 
 Una vez cumplidos los objetivos del último Mapa de su Hoja de Viaje, el Entrenador se habrá convertido en un _Maestro Pokémon_. El proceso Entrenador informará el logro por pantalla, indicando el Tiempo Total que le tomó toda la aventura, cuánto tiempo pasó bloqueado en las PokeNests, en cuántos Deadlocks estuvo involucrado, y cuántas veces Murió durante la hazaña (ver apartado siguiente).
 

--- a/proceso-mapa.md
+++ b/proceso-mapa.md
@@ -12,16 +12,17 @@ El proceso Mapa al ser ejecutado **obtendrá de la línea de comandos su nombre 
 
 ## Hilo Planificador
 
-El hilo Planificador será el encargado de habilitar a los procesos Entrenadores para que puedan actuar dentro del Mapa, ordenándolos **según un algoritmo de planificación de corto plazo Round Robin o SRDF**[^2].
+El hilo Planificador será el encargado de contestar las peticiones de los Entrenadores que actúan dentro del Mapa, ordenándolos **según un algoritmo de planificación de corto plazo Round Robin o SRDF**[^2].
 
 Gestionará una cola de Listos y una cola de Bloqueados. Ante cada modificación de estas colas, el Planificador **deberá informar por archivo de log la modificación realizada, y la lista de los Entrenadores en cada una de las colas**.
 
-Una vez elegido el Entrenador al que le corresponde realizar un movimiento, el hilo le enviará el mensaje de “turno concedido”. El Entrenador podrá responder indicando que desea:
+Mientras haya Entrenadores listos, el Planificador seleccionará a cuál atenderá según el algoritmo de planificación activo. Una vez seleccionado, el Planificador contestará una por una las peticiones que el Entrenador le haga, hasta que este solicite capturar un Pokemon, o hasta que consuma toda la ráfaga de ejecución (si el algoritmo activo fuera RR).
+
+Las posibles operaciones a atender son:
 
 1. **Conocer la ubicación de una PokeNest** - El Mapa contestará al Entrenador las coordenadas en que se encuentra la PokeNest de un Pokémon determinado
 1. **Moverse en alguna dirección** - El Mapa registrará dicho movimiento y contabilizará el uso de una unidad de tiempo al Entrenador
 1. **Capturar un Pokémon** - El Planificador moverá a dicho personaje a la cola de bloqueados. Descartará, si quedara, el quantum de tiempo restante del Entrenador y planificará al siguiente que se encuentre listo.
-1. **Notificar fin de objetivos** - El Planificador informará al Entrenador la ruta en que se encuentra el archivo de la Medalla del Mapa
 
 Eventualmente, el Planificador podrá detectar que un Entrenador se desconectó (cumplió los objetivos del Mapa, o murió). Cuando esto ocurra, deberá liberar todos los Pokémons que éste había capturado y, si correspondiera, otorgarlos a los Entrenadores bloqueados por ellos, desbloqueándolos. Al mismo tiempo, el Planificador eliminará al Entrenador de sus listas de Planificación.
 


### PR DESCRIPTION
> **TL;DR:** Vamos a hacer un cambio importante al enunciado, y estamos evaluando cuál es la mejor opción. Leé, analizá, y, _por favor_, opiná

Como se discutió en sisoputnfrba/foro#457, el algoritmo SRDF carece de sentido en el enunciado.

Al ser un algoritmo expropiativo, solamente se elegirá un Entrenador para atender cuando: a) recién se haya (re)conectado al Mapa; b) recién haya capturado un Pokemon; o c) se recargue el archivo de configuración entre que se expropia un Entrenador por fin de ráfaga y se atiende a otro que estaba en Listos.

c) es _muy_ improbable de ocurrir. a) y b), los casos normales, comparten un problema: el Entrenador aún no informó a qué PokeNest se quiere dirigir, por lo que se desconoce su Remaining Distance.

Este Pull Request busca corregir eso.

El primer paso es que el Entrenador deje de saber que es planificado. En lugar de esperar mensajes de "Turno concedido", el Entrenador se conecta al Mapa y pide conocer la ubicación de la primer PokeNest - y será el Mapa el que le conteste recién cuando lo elija "para ejecutar". Con esto, solucionamos a), dado que el Mapa siempre sabe a qué PokeNest se dirigen los Entrenadores que acaban de conectarse.

**Lo que falta** es solucionar b). Si mantenemos el hecho de que solicitar capturar un Pokemon interrumpe la ráfaga de ejecución (simulando una entrada/salida), el Entrenador va a solicitar capturar el Pokemon, y el Planificador lo va a expropiar "de la CPU". _Eventualmente_ (ya sea en ese momento, o cuando se libere el Pokemon que está esperando) el Entrenador va a ir a la cola de Listos, y recién al ser elegido para ejecutar va a recibir su confirmación de captura, pudiendo pedir la ubicación de la próxima PokeNest. Pero, para este momento, el Entrenador ya fue planificado - con su Remaining Distance en 0 (porque está en su objetivo), o con una Remaining Distance desconocida (si determinamos que al recibir el pedido de captura ya se considera que su objetivo es la PokeNest siguiente). Como sea, planificaríamos con esta Remaining Distance _ficticia_, y al preguntar por la próxima PokeNest, no tendríamos en cuenta este valor para la planificación - porque _ya es_ el Entrenador activo.
## Alternativas

La primer alternativa es hacer que **preguntar la ubicación de la PokeNest corte la ráfaga**. De algún modo, podemos decir que eso es lo que pasa cuando el Entrenador recién se conecta - envía el pedido y se va a Listos -, pero no estoy del todo seguro de si no trae algún inconveniente. Además, por cada captura expropiaríamos al Entrenador 2 veces (una por la captura, otra por la pregunta de la siguiente PokeNest) - nada del otro mundo, pero quizá queda medio raro. Lo más feo de esta alternativa es que el Entrenador pierde su ráfaga sin realmente tener por qué pasar por el estado de Bloqueado.

La segunda alternativa es hacer una **cola con prioridad** para los Entrenadores que recién capturaron un Pokemon. Al asignarle un Pokemon, se lo envía a una cola RR Q=1 de Listos, con mayor prioridad que la cola normal de Listos (la RR/SRDF), para que el Entrenador pueda preguntar por la próxima PokeNest y, como el Quantum es 1, vaya a la cola normal de Listos con su Remaining Distance ya conocida.

La tercer alternativa es hacer **que el SRDF sea expropiativo**, por lo que cada vez que se "aprenda" la Remaining Distance de un Entrenador se replanifique. Para terminar de cubrir los casos, podríamos determinar un valor configurable para usar en lugar de la Remaining Distance de los Entrenadores cuya RD es desconocida (ie, cuando capturaron el Pokemon pero aún no preguntaron la siguiente PokeNest).

La cuarta alternativa es **estimar** los valores con que planificar. Habría que definir cómo interactúa esto con el cambio de algoritmo entre SRDF y RR (si se mantiene o "resetea" la estimación, etc).

No se me ocurren más alternativas _por l'ahora_.

Me gustaría tener _muchas_ opiniones, tanto de @sisoputnfrba/ayudantes como de todos los alumnos - que son quienes van a tener que implementarlo, je.
